### PR TITLE
fix: make ecsda compliant with WebCrypto spec

### DIFF
--- a/dist/msrcrypto.js
+++ b/dist/msrcrypto.js
@@ -17,9 +17,11 @@
 //*******************************************************************************
 
 // Don't enforce entropy in environments without document
-document = typeof document === 'undefined' ? {
-    attachEvent: function() {}
-} : document;
+if (typeof document === 'undefined') {
+    document = {
+        attachEvent: function() {}
+    };
+}
 
 var msrCryptoVersion = "1.4.1";
 var msrCrypto = msrCrypto || (function () {
@@ -8148,7 +8150,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.sign = function ( p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 
@@ -8160,7 +8162,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.verify = function ( p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 
@@ -8566,7 +8568,7 @@ function syncWorker() {
         try {
             result = msrcryptoWorker.jsCryptoRunner( { data: data });
         } catch (ex) {
-            this.onerror({ data: ex.description, type: "error" });
+            this.onerror({ data: ex.message, type: "error" });
             return;
         }
 

--- a/dist/msrcrypto.mjs
+++ b/dist/msrcrypto.mjs
@@ -17,9 +17,11 @@
 //*******************************************************************************
 
 // Don't enforce entropy in environments without document
-document = typeof document === 'undefined' ? {
-    attachEvent: function() {}
-} : document;
+if (typeof document === 'undefined') {
+    document = {
+        attachEvent: function() {}
+    };
+}
 
 var msrCryptoVersion = "1.4.1";
 var msrCrypto = msrCrypto || (function () {
@@ -8148,7 +8150,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.sign = function ( p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 
@@ -8160,7 +8162,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.verify = function ( p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 
@@ -8566,7 +8568,7 @@ function syncWorker() {
         try {
             result = msrcryptoWorker.jsCryptoRunner( { data: data });
         } catch (ex) {
-            this.onerror({ data: ex.description, type: "error" });
+            this.onerror({ data: ex.message, type: "error" });
             return;
         }
 

--- a/msrCrypto/msrcrypto.aes.js
+++ b/msrCrypto/msrcrypto.aes.js
@@ -599,8 +599,8 @@ var msrcryptoUtilities = (function () {
         }
 
         // If it's an ArrayBuffer, convert it to a Uint8Array first
-        if (typedArray.isView) {
-            typedArray = Uint8Array(typedArray);
+        if (typedArray.isView || getObjectType(typedArray) === "ArrayBuffer") {
+            typedArray = new Uint8Array(typedArray);
         }
 
         // A single element array will cause a new Array to be created with the length
@@ -2851,7 +2851,7 @@ function syncWorker() {
         try {
             result = msrcryptoWorker.jsCryptoRunner(/*@static_cast(typeEvent)*/{ data: data });
         } catch (ex) {
-            this.onerror({ data: ex.description, type: "error" });
+            this.onerror({ data: ex.message, type: "error" });
             return;
         }
 

--- a/msrCrypto/msrcrypto.js
+++ b/msrCrypto/msrcrypto.js
@@ -599,8 +599,8 @@ var msrcryptoUtilities = (function () {
         }
 
         // If it's an ArrayBuffer, convert it to a Uint8Array first
-        if (typedArray.isView) {
-            typedArray = Uint8Array(typedArray);
+        if (typedArray.isView || getObjectType(typedArray) === "ArrayBuffer") {
+            typedArray = new Uint8Array(typedArray);
         }
 
         // A single element array will cause a new Array to be created with the length
@@ -9081,7 +9081,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.sign = function ( /*@dynamic*/ p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 
@@ -9093,7 +9093,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.verify = function ( /*@dynamic*/ p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 

--- a/msrCrypto/scripts/ecdsa.js
+++ b/msrCrypto/scripts/ecdsa.js
@@ -193,7 +193,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.sign = function ( /*@dynamic*/ p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 
@@ -205,7 +205,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.verify = function ( /*@dynamic*/ p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 

--- a/msrCrypto/scripts/utilities.js
+++ b/msrCrypto/scripts/utilities.js
@@ -419,8 +419,8 @@ var msrcryptoUtilities = (function () {
         }
 
         // If it's an ArrayBuffer, convert it to a Uint8Array first
-        if (typedArray.isView) {
-            typedArray = Uint8Array(typedArray);
+        if (typedArray.isView || getObjectType(typedArray) === "ArrayBuffer") {
+            typedArray = new Uint8Array(typedArray);
         }
 
         // A single element array will cause a new Array to be created with the length

--- a/msrcrypto.js
+++ b/msrcrypto.js
@@ -513,8 +513,8 @@ var msrcryptoUtilities = (function () {
         }
 
         // If it's an ArrayBuffer, convert it to a Uint8Array first
-        if (typedArray.isView) {
-            typedArray = Uint8Array(typedArray);
+        if (typedArray.isView || getObjectType(typedArray) === "ArrayBuffer") {
+            typedArray = new Uint8Array(typedArray);
         }
 
         // A single element array will cause a new Array to be created with the length
@@ -8140,7 +8140,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.sign = function ( p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 
@@ -8152,7 +8152,7 @@ if (typeof operations !== "undefined") {
     msrcryptoEcdsa.verify = function ( p) {
 
         var hashName = p.algorithm.hash.name,
-            curve = cryptoECC.createCurve(p.algorithm.namedCurve.toUpperCase()),
+            curve = cryptoECC.createCurve(p.keyHandle.algorithm.namedCurve.toUpperCase()),
             hashFunc = msrcryptoHashFunctions[hashName.toLowerCase()],
             digest = hashFunc.computeHash(p.buffer);
 
@@ -8558,7 +8558,7 @@ function syncWorker() {
         try {
             result = msrcryptoWorker.jsCryptoRunner( { data: data });
         } catch (ex) {
-            this.onerror({ data: ex.description, type: "error" });
+            this.onerror({ data: ex.message, type: "error" });
             return;
         }
 


### PR DESCRIPTION
fix(error): include error message
fix: don't overwrite document which is readonly in browsers
fix(ecdsa): extract named curve from keyHandle

for compatibility with WebCrypto spec, the namedCurve parameter should be extracted from `keyHandle.algorithm.namedCurve`